### PR TITLE
Update dependencies

### DIFF
--- a/library/project.clj
+++ b/library/project.clj
@@ -3,11 +3,11 @@
   :url "https://github.com/mhjort/lein-clj-lambda/library"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[cheshire "5.5.0"]
-                 [com.fasterxml.jackson.core/jackson-core "2.5.3"]
-                 [com.fasterxml.jackson.core/jackson-databind "2.5.3"]
-                 [com.amazonaws/aws-java-sdk-core "1.10.77" :exclusions [com.fasterxml.jackson.core/jackson-databind]]
-                 [com.amazonaws/aws-java-sdk-lambda "1.10.77"]
-                 [com.amazonaws/aws-java-sdk-iam "1.10.77"]
-                 [com.amazonaws/aws-java-sdk-api-gateway "1.10.77"]
-                 [com.amazonaws/aws-java-sdk-s3 "1.10.77"]])
+  :dependencies [[cheshire "5.6.3"]
+                 [com.fasterxml.jackson.core/jackson-core "2.8.4"]
+                 [com.fasterxml.jackson.core/jackson-databind "2.8.4"]
+                 [com.amazonaws/aws-java-sdk-core "1.11.52" :exclusions [com.fasterxml.jackson.core/jackson-databind]]
+                 [com.amazonaws/aws-java-sdk-lambda "1.11.52"]
+                 [com.amazonaws/aws-java-sdk-iam "1.11.52"]
+                 [com.amazonaws/aws-java-sdk-api-gateway "1.11.52"]
+                 [com.amazonaws/aws-java-sdk-s3 "1.11.52"]])


### PR DESCRIPTION
## Cheshire changes

Source https://github.com/dakrone/cheshire/blob/master/ChangeLog.md

### Changes between Cheshire 5.6.3 and 5.6.2

* Fix float coercion when encoding

### Changes between Cheshire 5.6.2 and 5.6.1

* Fix type hints for newer clojure version
* Bump Jackson dependencies

### Changes between Cheshire 5.6.1 and 5.6.0

* Fix javac target for 1.6 compatibility

### Changes between Cheshire 5.6.0 and 5.5.0

* Fixes for type hinting
* Make :pretty option configurable to use custom pretty printer

### Changes between Cheshire 5.5.0 and 5.5.0

* Bump Jackson dependencies

## Jackson Core Changes

Source https://github.com/FasterXML/jackson-core/blob/master/release-notes/VERSION

2.8.4 (14-Oct-2016)

No changes since 2.8.3

2.8.3 (17-Sep-2016)

#318: Add support for writing `byte[]` via `JsonGenerator.writeEmbeddedObject()`

2.8.2 (30-Aug-2016)
2.8.1 (20-Jul-2016)

No changes since 2.8.0

2.8.0 (04-Jul-2016)

#86: Allow inclusion of request body for `JsonParseException`
 (contributed by LokeshN)
#117: Add `JsonParser.Feature.ALLOW_MISSING_VALUES` to support for missing values
 (contributed by LokeshN)
#136: Add `JsonpCharacterEscapes` for easier handling of potential problems
 with JSONP and rare but technically allowed \u2028 and \u2029 linefeed characters
#253: Add `JsonGenerator. writeEmbeddedObject()` to allow writes of opaque native types
 (suggested by Gregoire C)
#255: Relax ownership checks for buffers not to require increase in size
#257: Add `writeStartObject(Object pojo)` to streamline assignment of current value
#265: `JsonStringEncoder` should allow passing `CharSequence`
 (contributed by Mikael S)
#276: Add support for serializing using `java.io.DataOutput`
#277: Add new scalar-array write methods for `int`/`long`/`double` cases
#279: Support `DataInput` for parsing
#280: Add `JsonParser.finishToken()` to force full, non-lazy reading of current token
#281: Add `JsonEOFException` as sub-class of `JsonParseException`
#282: Fail to report error for trying to write field name outside Object (root level)
#285: Add `JsonParser.getText(Writer)`
 (contributed by LokesN)
#290: Add `JsonGenerator.canWriteFormattedNumbers()` for introspection
#294: Add `JsonGenerator.writeFieldId(long)` method to support binary formats
 with non-String keys
#296: `JsonParserSequence` skips a token on a switched Parser
 (reported by Kevin G)
- Add `JsonParser.currentToken()` and `JsonParser.currentTokenId()` as replacements
  for `getCurrentToken()` and `getCurrentTokenId()`, respectively. Existing methods
  will likely be deprecated in 2.9.

2.7.8 (not yet released)

#317: ArrayIndexOutOfBoundsException: 200 on floating point number with exactly
  200-length decimal part
 (reported by Allar H)

2.7.7 (27-Aug-2016)

#307: JsonGenerationException: Split surrogate on writeRaw() input thrown for
  input of a certain size
 (reported by Mike N)
#315: `OutOfMemoryError` when writing BigDecimal
 (reported by gmethwin@github)

2.7.6 (23-Jul-2016)

- Clean up of FindBugs reported possible issues.

2.7.5 (11-Jun-2016)
 
#280: FilteringGeneratorDelegate.writeUTF8String() should delegate to writeUTF8String()
 (reported by Tanguy L)

2.7.4 (29-Apr-2016)

#209: Make use of `_allowMultipleMatches` in `FilteringParserDelegate`
 (contributed by Lokesh N)
- Make `processor` transient in `JsonParseException`, `JsonGenerationException`
  to keep both Serializable

2.7.3 (16-Mar-2016)

No changes since 2.7.2.

2.7.2 (26-Feb-2016)

#246: Fix UTF8JsonGenerator to allow QUOTE_FIELD_NAMES to be toggled
 (suggested by philipa@github)

2.7.1 (02-Feb-2016)

No changes since 2.7.0.

2.7.0 (10-Jun-2016)

#37: JsonParser.getTokenLocation() doesn't update after field names
 (reported by Michael L)
#198: Add back-references to `JsonParser` / `JsonGenerator` for low-level parsing issues
 (via `JsonParseException`, `JsonGenerationException`)
#211: Typo of function name com.fasterxml.jackson.core.Version.isUknownVersion()
 (reported by timray@github)
#229: Array element and field token spans include previous comma.
- Implemented `ReaderBasedJsonParser.nextFieldName(SerializableString)`
  (to improved Afterburner performance over String/char[] sources)

2.6.6 (05-Apr-2016)

#248: VersionUtil.versionFor() unexpectedly return null instead of Version.unknownVersion()
 (reported by sammyhk@github)

2.6.5 (19-Jan-2016)
2.6.4 (07-Dec-2015)

No changes since 2.6.3.

2.6.3 (12-Oct-2015)

#220: Problem with `JsonParser.nextFieldName(SerializableString)` for byte-backed parser

2.6.2 (14-Sep-2015)

#213: Parser is sometimes wrong when using CANONICALIZE_FIELD_NAMES
 (reported by ichernev@github)
#216: ArrayIndexOutOfBoundsException: 128 when repeatedly serializing to a byte array
 (reported by geekbeast@github)

2.6.1 (09-Aug-2015)

#207: `ArrayIndexOutOfBoundsException` in `ByteQuadsCanonicalizer`
 (reported by Florian S, fschopp@github)

2.6.0 (17-Jul-2015)

#137: Allow filtering content read via `JsonParser` by specifying `JsonPointer`;
  uses new class `com.fasterxml.jackson.core.filter.FilteringParserDelegate`
  (and related, `TokenFilter`)
#177: Add a check so `JsonGenerator.writeString()` won't work if `writeFieldName()` expected.
#182: Inconsistent TextBuffer#getTextBuffer behavior
 (contributed by Masaru H)
#185: Allow filtering content written via `JsonGenerator` by specifying `JsonPointer`;
  uses new class `com.fasterxml.jackson.core.filter.FilteringGeneratorDelegate`
  (and related, `TokenFilter`)
#188: `JsonParser.getValueAsString()` should return field name for `JsonToken.FIELD_NAME`, not `null`
#189: Add `JsonFactory.Feature.USE_THREAD_LOCAL_FOR_BUFFER_RECYCLING` (default: true), which may
  be disabled to prevent use of ThreadLocal-based buffer recyling.
 (suggested by soldierkam@github)
#195: Add `JsonGenerator.getOutputBuffered()` to find out amount of content buffered,
  not yet flushed.
 (requested by Ruediger M)
#196: Add support for `FormatFeature` extension, for format-specifc Enum-backed
  parser/generator options
- Minor improvement to construction of "default PrettyPrinter": now overridable by data format
  modules
- Implement a new yet more optimized symbol table for byte-backed parsers
- Add `JsonParser.Feature.IGNORE_UNDEFINED`, useful for data formats like protobuf
- Optimize writing of String names (remove intermediate copy; with JDK7 no speed benefit)

2.5.5 (07-Dec-2015)

#220: Problem with `JsonParser.nextFieldName(SerializableString)` for byte-backed parser
#221: Fixed ArrayIndexOutOfBounds exception for character-based `JsonGenerator`
 (reported by a-lerion@github)

2.5.4 (09-Jun-2015)

No changes.


## Jackson Core Databind Changes

Source https://github.com/FasterXML/jackson-databind/blob/master/release-notes/VERSION

2.8.4 (14-Oct-2016)

#466: Jackson ignores Type information when raw return type is BigDecimal or BigInteger 
#1001: Parameter names module gets confused with delegate creator which is a static method
#1324: Boolean parsing with `StdDeserializer` is too slow with huge integer value
 (reported by pavankumar-parankusam@github)
#1383: Problem with `@JsonCreator` with 1-arg factory-method, implicit param names
#1384: `@JsonDeserialize(keyUsing = ...)` does not work correctly together with
  DefaultTyping.NON_FINAL
 (reported by Oleg Z)
#1385: Polymorphic type lost when using `@JsonValue`
 (reported by TomMarkuske@github)
#1389 Problem with handling of multi-argument creator with Enums
 (fix contributed by Pavel P)
#1392: Custom UnmodifiableSetMixin Fails in Jackson 2.7+ but works in Jackson 2.6
 (reported by Rob W)
#1395: Problems deserializing primitive `long` field while using `TypeResolverBuilder`
 (reported by UghZan3@github)
#1403: Reference-chain hints use incorrect class-name for inner classes
 (reported by Josh G)
#1411: MapSerializer._orderEntries should check for null keys
 (reported by Jörn H)

2.8.3 (17-Sep-2016)

#1351: `@JsonInclude(NON_DEFAULT)` doesn't omit null fields
 (reported by Gili T)
#1353: Improve error-handling for `java.net.URL` deserialization
#1361: Change `TokenBuffer` to use new `writeEmbeddedObject()` if possible

2.8.2 (30-Aug-2016)

#1315: Binding numeric values can BigDecimal lose precision
 (reported by Andrew S)
#1327: Class level `@JsonInclude(JsonInclude.Include.NON_EMPTY)` is ignored
 (reported by elruwen@github)
#1335: Unconditionally call `TypeIdResolver.getDescForKnownTypeIds`
 (contributed by Chris J-Y)

2.8.1 (20-Jul-2016)

#1256: `Optional.empty()` not excluded if property declared with type `Object`
#1288: Type id not exposed for `JsonTypeInfo.As.EXTERNAL_PROPERTY` even when `visible` set to `true`
 (reported by libetl@github)
#1289: Optimize construction of `ArrayList`, `LinkedHashMap` instances
#1291: Backward-incompatible behaviour of 2.8: deserializing enum types
   with two static factory methods fail by default
#1297: Deserialization of generic type with Map.class
 (reported by Arek G)
#1302: NPE for `ResolvedRecursiveType` in 2.8.0 due to caching

2.8.0 (04-Jul-2016)

#621: Allow definition of "ignorable types" without annotation (using
  `Mapper.configOverride(type).setIsIgnoredType(true)`
#867: Support `SerializationFeature.WRITE_EMPTY_JSON_ARRAYS ` for `JsonNode`
#903: Add `JsonGenerator` reference to `SerializerProvider`
#931: Add new method in `Deserializers.Base` to support `ReferenceType`
#960: `@JsonCreator` not working on a factory with no arguments for an enum type
 (reported by Artur J)
#990: Allow failing on `null` values for creator (add 
  `DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES`)
 (contributed by mkokho@github)
#999: External property is not deserialized
 (reported by Aleksandr O)
#1017: Add new mapping exception type ('InvalidTypeIdException') for subtype resolution errors
 (suggested by natnan@github)
#1028: Ignore USE_BIG_DECIMAL_FOR_FLOATS for NaN/Infinity
 (reported by Vladimir K, lightoze@github)
#1047: Allow use of `@JsonAnySetter` on a Map-valued field, no need for setter
#1082: Can not use static Creator factory methods for `Enum`s, with JsonCreator.Mode.PROPERTIES
 (contributed by Lokesh K)
#1084: Change `TypeDeserializerBase` to take `JavaType` for `defaultImpl`, NOT `Class`
#1126: Allow deserialization of unknown Enums using a predefined value
 (contributed by Alejandro R)
#1136: Implement `TokenBuffer.writeEmbeddedObject(Object)`
 (suggested by Gregoire C, gcxRun@github)
#1165: CoreXMLDeserializers does not handle time-only XMLGregorianCalendars
 (reported, contributed fix by Ross G)
#1181: Add the ability to specify the initial capacity of the ArrayNode
 (suggested by Matt V, mveitas@github)
#1184: Allow overriding of `transient` with explicit inclusion with `@JsonProperty`
 (suggested by Maarten B)
#1187: Refactor `AtomicReferenceDeserializer` into `ReferenceTypeDeserializer`
#1204: Add a convenience accessor `JavaType.hasContentType()` (true for container or reference type)
#1206: Add "anchor type" member for `ReferenceType`
#1211: Change `JsonValueSerializer` to get `AnnotatedMethod`, not "raw" method
#1217: `@JsonIgnoreProperties` on Pojo fields not working for deserialization
 (reported by Lokesh K)
#1221: Use `Throwable.addSuppressed()` directly and/or via try-with-resources
#1232: Add support for `JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES`
#1233: Add support for `JsonFormat.Feature.WRITE_SORTED_MAP_ENTRIES`
#1235: `java.nio.file.Path` support incomplete
 (reported by, fix contributed by Benson M)
#1261: JsonIdentityInfo broken deserialization involving forward references and/or cycles
 (reported by, fix contributed by Ari F)
#1270: Generic type returned from type id resolver seems to be ignored
 (reported by Benson M)
#1277: Add caching of resolved generic types for `TypeFactory`
 (requested by Andriy P)

2.7.8 (26-Sep-2016)

#877: @JsonIgnoreProperties`: ignoring the "cause" property of `Throwable` on GAE
#1359: Improve `JsonNode` deserializer to create `FloatNode` if parser supports
#1362: ObjectReader.readValues()` ignores offset and length when reading an array
 (reported by wastevenson@github)
#1363: The static field ClassUtil.sCached can cause a class loader leak
 (reported by Stuart D)
#1368: Problem serializing `JsonMappingException` due to addition of non-ignored
  `processor` property (added in 2.7)
 (reported, suggesed fix by Josh C)
#1383: Problem with `@JsonCreator` with 1-arg factory-method, implicit param names

2.7.7 (27-Aug-2016)

#1322: EnumMap keys not using enum's `@JsonProperty` values unlike Enum values
 (reported by MichaelChambers@github)
#1332: Fixed ArrayIndexOutOfBoundException for enum by index deser
 (reported by Max D)
#1344: Deserializing locale assumes JDK separator (underscore), does not
  accept RFC specified (hyphen)
 (reported by Jim M)

2.7.6 (23-Jul-2016)

#1215: Problem with type specialization for Maps with `@JsonDeserialize(as=subtype)`
 (reported by brentryan@github)
#1279: Ensure DOM parsing defaults to not expanding external entities
#1288: Type id not exposed for `JsonTypeInfo.As.EXTERNAL_PROPERTY` even when `visible` set to `true`
#1299: Timestamp deserialization error
 (reported by liyuj@github)
#1301: Problem with `JavaType.toString()` for recursive (self-referential) types
 (reported by Brian P)
#1307: `TypeWrappedDeserializer` doesn't delegate the `getNullValue()` method to `_deserializer`
 (reported by vfries@github)

2.7.5 (11-Jun-2016)

#1098: DeserializationFeature.FAIL_ON_INVALID_SUBTYPE does not work with
  `JsonTypeInfo.Id.CLASS`
 (reported by szaccaria@github)
#1223: `BasicClassIntrospector.forSerialization(...).findProperties` should
  respect MapperFeature.AUTO_DETECT_GETTERS/SETTERS?
 (reported by William H)
#1225: `JsonMappingException` should override getProcessor()
 (reported by Nick B)
#1228: @JsonAnySetter does not deserialize null to Deserializer's NullValue
 (contributed by Eric S)
#1231: `@JsonSerialize(as=superType)` behavior disallowed in 2.7.4
 (reported by Mark W)
#1248: `Annotated` returns raw type in place of Generic Type in 2.7.x
 (reported by Andrew J, apjoseph@github)
#1253: Problem with context handling for `TokenBuffer`, field name
#1260: `NullPointerException` in `JsonNodeDeserializer`
 (reported by Eric S)

2.7.4 (29-Apr-2016)

#1122: Jackson 2.7 and Lombok: 'Conflicting/ambiguous property name definitions'
#1178: `@JsonSerialize(contentAs=superType)` behavior disallowed in 2.7
#1186: SimpleAbstractTypeResolver breaks generic parameters
 (reported by tobiash@github)
#1189: Converter called twice results in ClassCastException
 (reported by carrino@github)
#1191: Non-matching quotes used in error message for date parsing
#1194: Incorrect signature for generic type via `JavaType.getGenericSignature
#1195: `JsonMappingException` not Serializable due to 2.7 reference to source (parser)
 (reported by mjustin@github)
#1197: `SNAKE_CASE` doesn't work when using Lombok's `@AllArgsConstructor`
#1198: Problem with `@JsonTypeInfo.As.EXTERNAL_PROPERTY`, `defaultImpl`, missing type id, NPE
#1203: `@JsonTypeInfo` does not work correctly for ReferenceTypes like `AtomicReference`
#1208: treeToValue doesn't handle POJONodes that contain exactly the requested value type
  (reported by Tom M)
- Improve handling of custom content (de)serializers for `AtomicReference`

2.7.3 (16-Mar-2016)

#1125: Problem with polymorphic types, losing properties from base type(s)
#1150: Problem with Object id handling, explicit `null` token
 (reported by Xavi T)
#1154: @JsonFormat.pattern on dates is now ignored if shape is not explicitely provided
 (reported by Yoann R)
#1161: `DeserializationFeature.READ_ENUMS_USING_TO_STRING` not dynamically
  changeable with 2.7
 (reported by asa-git@github)
- Minor fixes to `AnnotationIntrospector.findEnumValues()` to correct problems with
  merging of explicit enum value names.

2.7.2 (26-Feb-2016)

#1124: JsonAnyGetter ignores JsonSerialize(contentUsing=...)
 (reported by Jiri M)
#1128: UnrecognizedPropertyException in 2.7.1 for properties that work with version 2.6.5
 (reported by Roleek@github)
#1129: When applying type modifiers, don't ignore container types.
#1130: NPE in `StdDateFormat` hashCode and equals
 (reported by Kazuki S, kazuki43zoo@github)
#1134: Jackson 2.7 doesn't work with jdk6 due to use of `Collections.emptyIterator()`
 (reported by Timur S, saladinkzn@github)

2.7.1-1 (03-Feb-2016)

Special one-off "micro patch" for:

#1115: Problems with deprecated `TypeFactory.constructType(type, ctxt)` methods if `ctxt` is `null`

2.7.1 (02-Feb-2016)

#1079: Add back `TypeFactory.constructType(Type, Class)` as "deprecated" in 2.7.1
#1083: Field in base class is not recognized, when using `@JsonType.defaultImpl`
 (reported by Julian H)
#1095: Prevent coercion of `int` from empty String to `null` if
  `DeserializationFeature .FAIL_ON_NULL_FOR_PRIMITIVES` is `true`
 (reported by yzmyyff@github)
#1102: Handling of deprecated `SimpleType.construct()` too minimalistic
 (reported by Thibault K)
#1109: @JsonFormat is ignored by the DateSerializer unless either a custom pattern
  or a timezone are specified
 (contributed by Aleks S)

2.7.0 (10-Jan-2016)

#76: Problem handling datatypes Recursive type parameters
 (reported by Aram K)
#357: StackOverflowError with contentConverter that returns array type
 (reported by Florian S)
#432: `StdValueInstantiator` unwraps exceptions, losing context
 (reported by Miles K)
#497: Add new JsonInclude.Include feature to exclude maps after exclusion removes all elements
#803: Allow use of `StdDateFormat.setLenient()`
 (suggested by raj-ghodke@github)
#819: Add support for setting `FormatFeature` via `ObjectReader`, `ObjectWriter`
#857: Add support for java.beans.Transient (requires Java 7)
 (suggested by Thomas M)
#898: Add `ObjectMapper.getSerializerProviderInstance()`
#905: Add support for `@ConstructorProperties` (requires Java 7)
 (requested by Jonas K)
#909: Rename PropertyNamingStrategy CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES as SNAKE_CASE,
   PASCAL_CASE_TO_CAMEL_CASE as UPPER_CAMEL_CASE
 (suggested by marcottedan@github)
#915: ObjectMapper default timezone is GMT, should be UTC
 (suggested by Infrag@github)
#918: Add `MapperFeature.ALLOW_EXPLICIT_PROPERTY_RENAMING`
 (contributed by David H)
#924: `SequenceWriter.writeAll()` could accept `Iterable`
 (suggested by Jiri-Kremser@github(
#932: Rewrite ser/deser for `AtomicReference`, based on "optional" ser/desers
#933: Close some gaps to allow using the `tryToResolveUnresolved` flows
#936: Deserialization into List subtype with JsonCreator no longer works
 (reported by adamjoeldavis@github)
#948: Support leap seconds, any number of millisecond digits for ISO-8601 Dates.
 (contributed by Jesse W)
#952: Revert non-empty handling of primitive numbers wrt `NON_EMPTY`; make
  `NON_DEFAULT` use extended criteria
#957: Merge `datatype-jdk7` stuff in (java.nio.file.Path handling)
#959: Schema generation: consider active view, discard non-included properties
#963: Add PropertyNameStrategy `KEBAB_CASE`
 (requested by Daniel M)
#978: ObjectMapper#canSerialize(Object.class) returns false even though FAIL_ON_EMPTY_BEANS is disabled
 (reported by Shumpei A)
#997: Add `MapperFeature.OVERRIDE_PUBLIC_ACCESS_MODIFIERS`
#998: Allow use of `NON_DEFAULT` for POJOs without default constructor
#1000: Add new mapping exception type for enums and UUIDs
 (suggesed by natnan@github)
#1010: Support for array delegator
 (contributed by Hugo W)
#1011: Change ObjectWriter::withAttributes() to take a Map with some kind of wildcard types
 (suggested by David B)
#1043: @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) does not work on fields
 (reported by fabiolaa@github)
#1044: Add `AnnotationIntrospector.resolveSetterConflict(...)` to allow custom setter conflict resolution
 (suggested by clydebarrow@github)
- Make `JsonValueFormat` (self-)serializable, deserializable, to/from valid external
  value (as per JSON Schema spec)

INCOMPATIBILITIES:

- While unlikely to be problematic, #959 above required an addition of `SerializerProvider`
  argument for `depositSchemaProperty()` method `BeanProperty` and `PropertyWriter` interfaces
- JDK baseline now Java 7 (JDK 1.7), from Java 6/JDK 1.6

2.6.6 (05-Apr-2016)

#1088: NPE possibility in SimpleMixinResolver
 (reported by Laird N)
#1099: Fix custom comparator container node traversal
 (contributed by Daniel N)
#1108: Jackson not continue to parse after DeserializationFeature.FAIL_ON_INVALID_SUBTYPE error
 (reported by jefferyyuan@github)
#1112: Detailed error message from custom key deserializer is discarded
 (contributed by Benson M)
#1120: String value omitted from weirdStringException
 (reported by Benson M)
#1123: Serializing and Deserializing Locale.ROOT
 (reported by hookumsnivy@github)

2.6.5 (19-Jan-2016)

#1052: Don't generate a spurious NullNode after parsing an embedded object
 (reported by philipa@github)
#1061: Problem with Object Id and Type Id as Wrapper Object (regression in 2.5.1)
#1073: Add try-catch around `java.sql` type serializers
 (suggested by claudemt@github)
#1078: ObjectMapper.copy() still does not preserve _registeredModuleTypes
 (reported by ajonkisz@github)

2.6.4 (07-Dec-2015)

#984: JsonStreamContexts are not build the same way for write.. and convert methods
 (reported by Antibrumm@github)
#989: Deserialization from "{}" to java.lang.Object causes "out of END_OBJECT token" error
 (reported by Ievgen P)
#1003: JsonTypeInfo.As.EXTERNAL_PROPERTY does not work with a Delegate
 (reported by alexwen@github)
#1005: Synthetic constructors confusing Jackson data binding
 (reported by Jayson M)
#1013: `@JsonUnwrapped` is not treated as assuming `@JsonProperty("")`
 (reported by David B)
#1036: Problem with case-insensitive deserialization
 (repoted by Dmitry R)
- Fix a minor problem with `@JsonNaming` not recognizing default value

2.6.3 (12-Oct-2015)

#749: `EnumMap` serialization ignores `SerializationFeature.WRITE_ENUMS_USING_TO_STRING`
 (reported by scubasau@github)
#938: Regression: `StackOverflowError` with recursive types that contain `Map.Entry`
 (reported by jloisel@github)
#939: Regression: DateConversionError in 2.6.x 
 (reported by Andreas P, anpieber@github)
#940: Add missing `hashCode()` implementations for `JsonNode` types that did not have them
 (contributed by Sergio M)
#941: Deserialization from "{}" to ObjectNode field causes "out of END_OBJECT token" error
 (reported by Sadayuki F)
#942: Handle null type id for polymorphic values that use external type id
 (reported by Warren B, stormboy@github)
#943: Incorrect serialization of enum map key
 (reported by Benson M)
#944: Failure to use custom deserializer for key deserializer
 (contributed by Benson M)
#949: Report the offending substring when number parsing fails
 (contributed by Jesse W)
#965: BigDecimal values via @JsonTypeInfo/@JsonSubTypes get rounded
 (reported by gmjabs@github)

2.6.2 (14-Sep-2015)

#894: When using withFactory on ObjectMapper, the created Factory has a TypeParser
  which still has the original Factory
 (reported by lufe66@github)
#899: Problem serializing `ObjectReader` (and possibly `ObjectMapper`)
#913: ObjectMapper.copy does not preserve MappingJsonFactory features
 (reported, fixed by Daniel W)
#922: ObjectMapper.copy() does not preserve _registeredModuleTypes
#928: Problem deserializing External Type Id if type id comes before POJO

2.6.1 (09-Aug-2015)

#873: Add missing OSGi import
#881: BeanDeserializerBase having issues with non-CreatorProperty properties.
 (reported by dharaburda@github)
#884: ArrayIndexOutOfBoundException for `BeanPropertyMap` (with ObjectId)
 (reported by alterGauner@github)
#889: Configuring an ObjectMapper's DateFormat changes time zone
 (reported by Andy W, wilkinsona@github)
#890: Exception deserializing a byte[] when the target type comes from an annotation
 (reported by gmjabs@github)

2.6.0 (19-Jul-2015)

#77: Allow injection of 'transient' fields
#95: Allow read-only properties with `@JsonIgnoreProperties(allowGetters=true)`
#222: EXTERNAL_PROPERTY adds property multiple times and in multiple places
 (reported by Rob E, thatsnotright@github)
#296: Serialization of transient fields with public getters (add
    MapperFeature.PROPAGATE_TRANSIENT_MARKER)
 (suggested by Michal L)
#312: Support Type Id mappings where two ids map to same Class
#348: ObjectMapper.valueToTree does not work with @JsonRawValue
 (reported by Chris P, pimlottc@github)
#504: Add `DeserializationFeature.USE_LONG_FOR_INTS`
 (suggested by Jeff S)
#624: Allow setting external `ClassLoader` to use, via `TypeFactory`
#649: Make `BeanDeserializer` use new `parser.nextFieldName()` and `.hasTokenId()` methods
#664: Add `DeserializationFeature.ACCEPT_FLOAT_AS_INT` to prevent coercion of floating point
 numbers int `int`/`long`/`Integer`/`Long`
 (requested by wenzis@github)
#677: Specifying `Enum` value serialization using `@JsonProperty`
 (requested by Allen C, allenchen1154@github)
#679: Add `isEmpty()` implementation for `JsonNode` serializers
#688: Provide a means for an ObjectMapper to discover mixin annotation classes on demand
 (requested by Laird N)
#689: Add `ObjectMapper.setDefaultPrettyPrinter(PrettyPrinter)`
 (requested by derknorton@github)
#696: Copy constructor does not preserve `_injectableValues`
 (reported by Charles A)
#698: Add support for referential types (ReferenceType)
#700: Cannot Change Default Abstract Type Mapper from LinkedHashMap
 (reported by wealdtech@github)
#725: Auto-detect multi-argument constructor with implicit names if it is the only visible creator
#727: Improve `ObjectWriter.forType()` to avoid forcing base type for container types
#734: Add basic error-recovery for `ObjectReader.readValues()`
#737: Add support for writing raw values in TokenBuffer
 (suggested by Guillaume S, gsmet@github)
#740: Ensure proper `null` (as empty) handling for `AtomicReference`
#741: Pass `DeserializationContext' argument for `JsonDeserializer` methods "getNullValue()"
 and "getEmptyValue()"
#743: Add `RawValue` helper type, for piping raw values through `TokenBuffer`
#756: Disabling SerializationFeature.FAIL_ON_EMPTY_BEANS does not affect `canSerialize()`
 (reported by nickwongdev@github)
#762: Add `ObjectWriter.withoutRootName()`, `ObjectReader.withoutRootName()`
#765: `SimpleType.withStaticTyping()` impl incorrect
#769: Fix `JacksonAnnotationIntrospector.findDeserializer` to return `Object` (as per
  `AnnotationIntrospector`); similarly for other `findXxx(De)Serializer(...)` methods
#777: Allow missing build method if its name is empty ("")
 (suggested by galdosd@github)
#781: Support handling of `@JsonProperty.required` for Creator methods
#787: Add `ObjectMapper setFilterProvider(FilterProvider)` to allow chaining
 (suggested by rgoldberg@githin)
#790: Add `JsonNode.equals(Comparator<JsonNode>, JsonNode)` to support
  configurable/external equality comparison
#794: Add `SerializationFeature.WRITE_DATES_WITH_ZONE_ID` to allow inclusion/exclusion of
  timezone id for date/time values (as opposed to timezone offset)
#795: Converter annotation not honored for abstract types
 (reported by myrosia@github)
#797: `JsonNodeFactory` method `numberNode(long)` produces `IntNode` for small numbers
#810: Force value coercion for `java.util.Properties`, so that values are `String`s
#811: Add new option, `JsonInclude.Include.NON_ABSENT` (to support exclusion of
  JDK8/Guava Optionals)
#812: Java 8 breaks Class-value annotation properties, wrt generics: need to work around
#813: Add support for new property of `@JsonProperty.access` to support
  read-only/write-only use cases
#820: Add new method for `ObjectReader`, to bind from JSON Pointer position
 (contributed by Jerry Y, islanderman@github)
#824: Contextual `TimeZone` changes don't take effect wrt `java.util.Date`,
  `java.util.Calendar` serialization
#826: Replaced synchronized HashMap with ConcurrentHashMap in TypeDeserializerBase._findDeserializer
 (contributed by Lars P)
#827: Fix for polymorphic custom map key serializer
 (reported by mjr6140@gitgub)
#828: Respect DeserializationFeatures.WRAP_EXCEPTIONS in CollectionDeserializer
 (contributed by Steve G, thezerobit@github)
#840: Change semantics of `@JsonPropertyOrder(alphabetic)` to only count `true` value
#848: Custom serializer not used if POJO has `@JsonValue`
#849: Possible problem with `NON_EMPTY` exclusion, `int`s, `Strings`
#868: Annotations are lost in the case of duplicate methods
- Remove old cglib compatibility tests; cause problems in Eclipse
- Add `withFilterId()` method in `JsonSerializer` (demote from `BeanSerializer`)

2.5.5 (07-Dec-2015)

#844: Using JsonCreator still causes invalid path references in JsonMappingException
 (reported by Ian B)
#852: Accept scientific number notation for quoted numbers too
#878: serializeWithType on BeanSerializer does not setCurrentValue
 (reported by Chi K, chikim79@github)

## AWS SDK Changes

Read from https://aws.amazon.com/releasenotes/Java
