### PR TITLE
Retry create-lambda-function to work around a race condition in the AWS API

### DIFF
--- a/library/project.clj
+++ b/library/project.clj
@@ -5,4 +5,5 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/data.json "0.2.6"]
                  [prismatic/schema "1.1.4"]
-                 [com.amazonaws/aws-java-sdk-bundle "1.11.112"]])
+                 [com.amazonaws/aws-java-sdk-bundle "1.11.112"]
+                 [robert/bruce "0.8.0"]])


### PR DESCRIPTION
There seems to be a race condition in the Amazon API which can cause function creation to fail if the role used has only recently been created. Other people have reported the same behaviour:

https://stackoverflow.com/questions/36419442/the-role-defined-for-the-function-cannot-be-assumed-by-lambda
https://stackoverflow.com/questions/37503075/invalidparametervalueexception-the-role-defined-for-the-function-cannot-be-assu

The best workaround seems to be to retry `create-lambda-function` until it succeeds.