### PR TITLE
Add support for default region

### DIFF
--- a/library/src/clj_lambda/schema.clj
+++ b/library/src/clj_lambda/schema.clj
@@ -9,7 +9,7 @@
 (defn- environment-config [install?]
   {(s/optional-key :api-gateway) {:name String}
    :function-name String
-   :region String
+   (s/optional-key :region) String
    (define-key :handler install?) String
    (define-key :memory-size install?) s/Int
    (define-key :timeout install?) s/Int


### PR DESCRIPTION
This pull request makes specifying `:region` optional in `project.clj`, using the default region if it's not. This allows the user to specify the region in their `~/.aws/config` file, or `AWS_REGION` environment variable.