### PR TITLE
Add vpc configuration to create lambda function

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Create S3 bucket and create following configuration into `project.clj`
                                        :Action ["sqs:*"]
                                        :Resource ["arn:aws:sqs:eu-west-1:*"]}]
                   :s3 {:bucket "your-bucket"  ; Optional, if not specified default bucket will be generated
-                       :object-key "lambda.jar"}}]
+                       :object-key "lambda.jar"}
+                  :vpc {:security-group-ids ["sg-xxxx"]
+                        :subnet-ids ["subnet-xxxxxx"]}}]
           "production" [{:api-gateway {:name "DemoApiProduction"} ; Optional, if you want to access via API Gateway
                          :handler "lambda-demo.LambdaFn"
                          :memory-size 1024
@@ -39,7 +41,9 @@ Create S3 bucket and create following configuration into `project.clj`
                                        "SOME_OTHER_ENV_VAR" "another val"}
                          :region "eu-west-1" ; Optional, when not specified the default region specified in your AWS config will be used
                          :s3 {:bucket "your-bucket"
-                              :object-key "lambda.jar"}}]}
+                              :object-key "lambda.jar"}
+                         :vpc {:security-group-ids ["sg-xxxx"]
+                               :subnet-ids ["subnet-xxxxxx"]}}]}
 ```
 
 Then run

--- a/library/src/clj_lambda/schema.clj
+++ b/library/src/clj_lambda/schema.clj
@@ -16,7 +16,9 @@
    (s/optional-key :environment) {String String}
    (s/optional-key :policy-statements) [{s/Keyword s/Any}]
    (s/optional-key :s3) {:bucket String
-                         :object-key String}})
+                         :object-key String}
+   (s/optional-key :vpc) {:security-group-ids [String]
+                          :subnet-ids [String]}})
 
 (def ConfigSchemaForInstall
   [(environment-config true)])


### PR DESCRIPTION
AWS users with a VPC are going to want to configure their Lambdas to run inside their VPCs (we do!). 

This PR adds the optional configuration key `:vpc` allowing users to specify both `:security-group-ids` and `:subnet-ids`. These fields must both be configured with appropriate lists of values.