### PR TITLE
additional retries when creating AWS lambda function

### DIFF
--- a/lein-plugin/project.clj
+++ b/lein-plugin/project.clj
@@ -1,10 +1,10 @@
-(defproject lein-clj-lambda "0.11.0"
+(defproject lein-clj-lambda "0.11.1-SNAPSHOT"
   :description "Leiningen plugin for AWS Lambda deployment"
   :url "https://github.com/mhjort/clj-lambda-deploy"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [clj-lambda "0.7.0"]
+                 [clj-lambda "0.7.1-SNAPSHOT"]
                  [org.clojure/tools.cli "0.3.5"]]
   :min-lein-version "2.7.1"
   :eval-in-leiningen true)

--- a/library/project.clj
+++ b/library/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-lambda "0.7.0"
+(defproject clj-lambda "0.7.1-SNAPSHOT"
   :description "Clojure utilities for AWS Lambda deployment"
   :url "https://github.com/mhjort/lein-clj-lambda/library"
   :license {:name "Eclipse Public License"

--- a/library/src/clj_lambda/aws.clj
+++ b/library/src/clj_lambda/aws.clj
@@ -132,7 +132,7 @@
         ;   https://stackoverflow.com/questions/36419442/the-role-defined-for-the-function-cannot-be-assumed-by-lambda
         ;   https://stackoverflow.com/questions/37503075/invalidparametervalueexception-the-role-defined-for-the-function-cannot-be-assu
         (try-try-again
-          {:decay :exponential :sleep 1000 :tries 3}
+          {:decay :exponential :sleep 1000 :tries 10}
           create-lambda-fn (-> env-settings
                                (select-keys [:function-name :handler :timeout
                                              :environment :memory-size :vpc])


### PR DESCRIPTION
In my the existing 3 retries wasn't quite enough, so I raised the limit to 10.

The only downside I can see is the potential for a longer delay before the call times out (in situations where the aws api is failing for some unrecoverable reason).